### PR TITLE
Upgrade CLI to 5.8.0

### DIFF
--- a/Formula/pgd-cli.rb
+++ b/Formula/pgd-cli.rb
@@ -10,7 +10,7 @@ class PgdCli < Formula
     depends_on "libpq"
 
     if Hardware::CPU.arm?
-      url "https://downloads.enterprisedb.com/public/homebrew-edb/raw/files/pgd-cli_5.8.0_darwin_arm64.tar.gz", using: HomebrewCurlDownloadStrategy
+      url "https://downloads.enterprisedb.com/public/homebrew-edb/raw/versions/5.8.0-1/pgd-cli_5.8.0_darwin_arm64.tar.gz", using: HomebrewCurlDownloadStrategy
       sha256 "dd1a6872aaaa446f4e3cd383c50e238946e4a9d0387db5fe3da63f3757f4d4b4"
 
       def install
@@ -21,7 +21,7 @@ class PgdCli < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://downloads.enterprisedb.com/public/homebrew-edb/raw/files/pgd-cli_5.8.0_darwin_amd64.tar.gz", using: HomebrewCurlDownloadStrategy
+      url "https://downloads.enterprisedb.com/public/homebrew-edb/raw/versions/5.8.0-1/pgd-cli_5.8.0_darwin_amd64.tar.gz", using: HomebrewCurlDownloadStrategy
       sha256 "1f066e55c42230ff6f7d439752fb2617b945f135398ffdce7ba4ebf0ba256ada"
 
       def install

--- a/Formula/pgd-cli.rb
+++ b/Formula/pgd-cli.rb
@@ -4,12 +4,14 @@
 class PgdCli < Formula
   desc "Postgres Distributed CLI"
   homepage "https://github.com/enterprisedb/homebrew-tap"
-  version "5.5.0"
+  version "5.8.0"
 
   on_macos do
+    depends_on "libpq"
+
     if Hardware::CPU.arm?
-      url "https://downloads.enterprisedb.com/public/homebrew-edb/raw/files/pgd-cli_5.5.0_darwin_arm64.tar.gz", using: HomebrewCurlDownloadStrategy
-      sha256 "0cb20deb8ecbd293ae7719a1bd7b3bbc4281f84b3ef0d95ff0230d36b0c8c503"
+      url "https://downloads.enterprisedb.com/public/homebrew-edb/raw/files/pgd-cli_5.8.0_darwin_arm64.tar.gz", using: HomebrewCurlDownloadStrategy
+      sha256 "dd1a6872aaaa446f4e3cd383c50e238946e4a9d0387db5fe3da63f3757f4d4b4"
 
       def install
         bin.install "pgd"
@@ -19,8 +21,8 @@ class PgdCli < Formula
       end
     end
     if Hardware::CPU.intel?
-      url "https://downloads.enterprisedb.com/public/homebrew-edb/raw/files/pgd-cli_5.5.0_darwin_amd64.tar.gz", using: HomebrewCurlDownloadStrategy
-      sha256 "95af066457229afa100b76c58524a66bdbaecdae502f6e7eb391c7458cd7a95c"
+      url "https://downloads.enterprisedb.com/public/homebrew-edb/raw/files/pgd-cli_5.8.0_darwin_amd64.tar.gz", using: HomebrewCurlDownloadStrategy
+      sha256 "1f066e55c42230ff6f7d439752fb2617b945f135398ffdce7ba4ebf0ba256ada"
 
       def install
         bin.install "pgd"


### PR DESCRIPTION
Tested the formula locally and works.

```
$ curl -LO https://raw.githubusercontent.com/EnterpriseDB/homebrew-tap/7c491b6777f689bac1cad9927652844affa7a0cc/Formula/pgd-cli.rb
$ brew install ./pgd-cli-rb
```

```
Phils-MacBook-Pro-3 ➜  bdr git:(REL_5_STABLE) ✗ ./dev-tools/pgdcluster.py --force-clean
No matching processes belonging to you were found
Starting up a 3-node cluster with data in /Users/phil/edb/bdr/pgdcluster-data
Starting up node0 (data) at 6000
Connect: psql -U postgres -p 6000 pgdtest
Starting up node1 (data) at 6001
Connect: psql -U postgres -p 6001 pgdtest
Starting up node2 (data) at 6002
Connect: psql -U postgres -p 6002 pgdtest
Phils-MacBook-Pro-3 ➜  bdr git:(REL_5_STABLE) ✗ pgd --dsn 'host=localhost dbname=pgdtest user=postgres port=6000' show-nodes
Node  Group    Type Current State Target State Status Node ID    SeqID Database
----- -------- ---- ------------- ------------ ------ ---------- ----- --------
node0 pgdgroup data ACTIVE        ACTIVE       Up     1007543451 1     pgdtest
node1 pgdgroup data ACTIVE        ACTIVE       Up     1148549230 2     pgdtest
node2 pgdgroup data ACTIVE        ACTIVE       Up     3367056606 3     pgdtest
Phils-MacBook-Pro-3 ➜  bdr git:(REL_5_STABLE) ✗ pgd --version
PGD Management Tool 5.8.0
Phils-MacBook-Pro-3 ➜  bdr git:(REL_5_STABLE) ✗ which pgd
/opt/homebrew/bin/pgd
```